### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/Controller/ElfsightController.php
+++ b/Controller/ElfsightController.php
@@ -3,11 +3,11 @@
 namespace YsTools\Bundle\OroCommerceElfsightBundle\Controller;
 
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
-use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Oro\Bundle\SecurityBundle\Attribute\AclAncestor;
 use Oro\Bundle\UserBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class ElfsightController extends AbstractController
@@ -18,10 +18,8 @@ class ElfsightController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/register", name="ystools_orocommerce_elfsight_register")
-     * @AclAncestor("oro_cms_content_widget_view")
-     */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/register', name: 'ystools_orocommerce_elfsight_register')]
+    #[AclAncestor('oro_cms_content_widget_view')]
     public function registerAction()
     {
         if ($this->tokenStorage->getToken()) {

--- a/DependencyInjection/YsToolsOroCommerceElfsightExtension.php
+++ b/DependencyInjection/YsToolsOroCommerceElfsightExtension.php
@@ -29,7 +29,7 @@ class YsToolsOroCommerceElfsightExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return self::ALIAS;
     }

--- a/Form/Type/ElfsightWidgetIdentifierType.php
+++ b/Form/Type/ElfsightWidgetIdentifierType.php
@@ -13,7 +13,7 @@ class ElfsightWidgetIdentifierType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
@@ -21,7 +21,7 @@ class ElfsightWidgetIdentifierType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'elfsight_identifier';
     }

--- a/YsToolsOroCommerceElfsightBundle.php
+++ b/YsToolsOroCommerceElfsightBundle.php
@@ -10,7 +10,7 @@ class YsToolsOroCommerceElfsightBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?\Symfony\Component\DependencyInjection\Extension\ExtensionInterface
     {
         return new YsToolsOroCommerceElfsightExtension();
     }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "oro/commerce": "5.1.*"
+        "oro/commerce": "6.0.*"
     },
     "autoload": {
         "psr-4": { "YsTools\\Bundle\\OroCommerceElfsightBundle\\": "" },


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied
